### PR TITLE
[PHPStanRules] Allow native ReflectionFunction on PreferredClassRule

### DIFF
--- a/config/rules.neon
+++ b/config/rules.neon
@@ -234,7 +234,6 @@ services:
                 PhpParser\Builder\Param: Rector\Core\PhpParser\Builder\ParamBuilder
                 PhpParser\Builder\Property: Rector\Core\PhpParser\Builder\PropertyBuilder
                 PhpParser\Builder\TraitUse: Rector\Core\PhpParser\Builder\TraitUseBuilder
-                ReflectionFunction: PHPStan\Reflection\FunctionReflection
 
     -
         class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule

--- a/tests/Rule/FileProcessorRectorConstructorContractRule/FileProcessorRectorConstructorContractRuleTest.php
+++ b/tests/Rule/FileProcessorRectorConstructorContractRule/FileProcessorRectorConstructorContractRuleTest.php
@@ -27,7 +27,7 @@ final class FileProcessorRectorConstructorContractRuleTest extends AbstractServi
     {
         yield [__DIR__ . '/Fixture/CorrectFileProcessor.php', []];
 
-        yield [__DIR__ . '/Fixture/WrongFileProcessor.php', [[FileProcessorRectorConstructorContractRule::ERROR_MESSAGE, 10]]];
+        yield [__DIR__ . '/Fixture/WrongFileProcessor.php', [[FileProcessorRectorConstructorContractRule::ERROR_MESSAGE, 11]]];
     }
 
     protected function getRule(): Rule

--- a/tests/Rule/FileProcessorRectorConstructorContractRule/Fixture/CorrectFileProcessor.php
+++ b/tests/Rule/FileProcessorRectorConstructorContractRule/Fixture/CorrectFileProcessor.php
@@ -6,6 +6,7 @@ namespace Rector\PHPStanRules\Tests\Rule\FileProcessorRectorConstructorContractR
 
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\Configuration;
 use Rector\PHPStanRules\Tests\Rule\FileProcessorRectorConstructorContractRule\Source\Contract\SomeRectorInterface;
 
 final class CorrectFileProcessor implements FileProcessorInterface
@@ -18,11 +19,11 @@ final class CorrectFileProcessor implements FileProcessorInterface
     ) {
     }
 
-    public function supports(File $file): bool
+    public function supports(File $file, Configuration $configuration): bool
     {
     }
 
-    public function process(array $files): void
+    public function process(File $file, Configuration $configuration): void
     {
     }
 

--- a/tests/Rule/FileProcessorRectorConstructorContractRule/Fixture/WrongFileProcessor.php
+++ b/tests/Rule/FileProcessorRectorConstructorContractRule/Fixture/WrongFileProcessor.php
@@ -6,14 +6,15 @@ namespace Rector\PHPStanRules\Tests\Rule\FileProcessorRectorConstructorContractR
 
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\Configuration;
 
 final class WrongFileProcessor implements FileProcessorInterface
 {
-    public function supports(File $file): bool
+    public function supports(File $file, Configuration $configuration): bool
     {
     }
 
-    public function process(array $files): void
+    public function process(File $file, Configuration $configuration): void
     {
     }
 

--- a/tests/Rule/ForbiddenInterfacesTogetherRule/Fixture/Mixture.php
+++ b/tests/Rule/ForbiddenInterfacesTogetherRule/Fixture/Mixture.php
@@ -7,6 +7,7 @@ namespace Rector\PHPStanRules\Tests\Rule\ForbiddenInterfacesTogetherRule\Fixture
 use Rector\Core\Contract\Processor\FileProcessorInterface;
 use Rector\Core\Contract\Rector\RectorInterface;
 use Rector\Core\ValueObject\Application\File;
+use Rector\Core\ValueObject\Configuration;
 use Symplify\RuleDocGenerator\ValueObject\RuleDefinition;
 
 final class Mixture implements RectorInterface, FileProcessorInterface
@@ -15,11 +16,11 @@ final class Mixture implements RectorInterface, FileProcessorInterface
     {
     }
 
-    public function supports(File $file): bool
+    public function supports(File $file, Configuration $configuration): bool
     {
     }
 
-    public function process(array $files): void
+    public function process(File $file, Configuration $configuration): void
     {
     }
 

--- a/tests/Rule/ForbiddenInterfacesTogetherRule/ForbiddenInterfacesTogetherRuleTest.php
+++ b/tests/Rule/ForbiddenInterfacesTogetherRule/ForbiddenInterfacesTogetherRuleTest.php
@@ -31,7 +31,7 @@ final class ForbiddenInterfacesTogetherRuleTest extends AbstractServiceAwareRule
         );
         $errorMessage = sprintf(ForbiddenInterfacesTogetherRule::ERROR_MESSAGE, $groupAsStrings);
 
-        yield [__DIR__ . '/Fixture/Mixture.php', [[$errorMessage, 12]]];
+        yield [__DIR__ . '/Fixture/Mixture.php', [[$errorMessage, 13]]];
 
         yield [__DIR__ . '/Fixture/SkipSeparated.php', []];
     }


### PR DESCRIPTION
It can be used for native reflection usage, ref 

https://github.com/rectorphp/rector-src/pull/466/files#diff-08a6fd7d71db5a18ed50027eaf1bc3ab26eb70e6ab0a6349a0885b4fb767e35dR39-R43

as PHPStan's NativeParameterReflection cannot get default value.