### PR TITLE
Fix TypeAndNameAnalyzer service not found

### DIFF
--- a/src/NodeAnalyzer/SymfonyConfigMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/SymfonyConfigMethodCallAnalyzer.php
@@ -7,22 +7,27 @@ namespace Rector\PHPStanRules\NodeAnalyzer;
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator;
-use Symplify\PHPStanRules\NodeAnalyzer\TypeAndNameAnalyzer;
+use PHPStan\Type\TypeWithClassName;
+use Symplify\Astral\Naming\SimpleNameResolver;
 
 final class SymfonyConfigMethodCallAnalyzer
 {
     public function __construct(
-        private TypeAndNameAnalyzer $typeAndNameAnalyzer
+        private SimpleNameResolver $simpleNameResolver
     ) {
     }
 
     public function isServicesSet(MethodCall $methodCall, Scope $scope): bool
     {
-        return $this->typeAndNameAnalyzer->isMethodCallTypeAndName(
-            $methodCall,
-            $scope,
-            ServicesConfigurator::class,
-            'set'
-        );
+        $callerType = $scope->getType($methodCall->var);
+        if (! $callerType instanceof TypeWithClassName) {
+            return false;
+        }
+
+        if (! is_a($callerType->getClassName(), ServicesConfigurator::class, true)) {
+            return false;
+        }
+
+        return $this->simpleNameResolver->isName($methodCall->name, 'set');
     }
 }

--- a/src/NodeAnalyzer/SymfonyConfigMethodCallAnalyzer.php
+++ b/src/NodeAnalyzer/SymfonyConfigMethodCallAnalyzer.php
@@ -6,7 +6,7 @@ namespace Rector\PHPStanRules\NodeAnalyzer;
 
 use PhpParser\Node\Expr\MethodCall;
 use PHPStan\Analyser\Scope;
-use Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator;
+use PHPStan\Type\ObjectType;
 use PHPStan\Type\TypeWithClassName;
 use Symplify\Astral\Naming\SimpleNameResolver;
 
@@ -24,7 +24,10 @@ final class SymfonyConfigMethodCallAnalyzer
             return false;
         }
 
-        if (! is_a($callerType->getClassName(), ServicesConfigurator::class, true)) {
+        $callerTypeObjectType = new ObjectType($callerType->getClassName());
+        $serviceConfiguratorObjectType = new ObjectType('Symfony\Component\DependencyInjection\Loader\Configurator\ServicesConfigurator');
+
+        if (! $serviceConfiguratorObjectType->isSuperTypeOf($callerTypeObjectType)->yes()) {
             return false;
         }
 


### PR DESCRIPTION
Ref https://github.com/rectorphp/rector-src/pull/950#issuecomment-932791658 due new symplify release which remove the service https://github.com/symplify/symplify/compare/9.4.69...9.4.70#diff-82e0501b5cae5f14a934c7179e008e789e5160e4cadca9bc75e80d7919714edc