### PR TITLE
Fix CI build

### DIFF
--- a/config/services.neon
+++ b/config/services.neon
@@ -1,3 +1,6 @@
+includes:
+    - ../vendor/symplify/phpstan-rules/packages/symfony/config/services.neon
+
 services:
     - Rector\PHPStanRules\TypeAnalyzer\InlineableTypeAnalyzer
     - Rector\PHPStanRules\TypeAnalyzer\AllowedAutoloadedTypeAnalyzer

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,3 @@
-includes:
-    - config/config.neon
-
 parameters:
     level: max
 

--- a/tests/Rule/ForbiddenComplexArrayConfigInSetRule/config/configured_rule.neon
+++ b/tests/Rule/ForbiddenComplexArrayConfigInSetRule/config/configured_rule.neon
@@ -2,6 +2,7 @@ includes:
     - ../../../../vendor/symplify/phpstan-rules/config/services/services.neon
 
 services:
+    - Symplify\PHPStanRules\Symfony\NodeAnalyzer\SymfonyPhpConfigClosureAnalyzer
     -
         class: Rector\PHPStanRules\Rule\ForbiddenComplexArrayConfigInSetRule
         tags: [phpstan.rules.rule]

--- a/tests/Rule/ForbiddenComplexArrayConfigInSetRule/config/configured_rule.neon
+++ b/tests/Rule/ForbiddenComplexArrayConfigInSetRule/config/configured_rule.neon
@@ -1,8 +1,8 @@
 includes:
     - ../../../../vendor/symplify/phpstan-rules/config/services/services.neon
+    - ../../../../config/services.neon
 
 services:
-    - Symplify\PHPStanRules\Symfony\NodeAnalyzer\SymfonyPhpConfigClosureAnalyzer
     -
         class: Rector\PHPStanRules\Rule\ForbiddenComplexArrayConfigInSetRule
         tags: [phpstan.rules.rule]


### PR DESCRIPTION
Current test build got the following error:

```bash
There were 43 errors:

1) Rector\PHPStanRules\Tests\Rule\CallConfigureWithArrayRule\CallConfigureWithArrayRuleTest::testRule with data set #0 ('/home/runner/work/phpstan-rul...ig.php', array())

_PHPStan_76800bfb5\Nette\DI\ServiceCreationException: Service of type Rector\PHPStanRules\Rule\ForbiddenComplexArrayConfigInSetRule: Service of type Symplify\PHPStanRules\Symfony\NodeAnalyzer\SymfonyPhpConfigClosureAnalyzer needed by $symfonyPhpConfigClosureAnalyzer in __construct() not found. Did you add it to configuration file?
```

This PR patch it.