### PR TITLE
Configure ForbiddenFuncCallRule to suggest alternatives in errors

### DIFF
--- a/config/rules.neon
+++ b/config/rules.neon
@@ -209,9 +209,9 @@ services:
             forbiddenFunctions:
                 'dump_node': ''
 
-                'preg_match': 'use Strings::match() instead'
-                'preg_match_all': 'use Strings::matchAll() instead'
-                'preg_replace': 'use Strings::replace() instead'
+                'preg_match': 'use "Nette\Utils\Strings::match()" instead'
+                'preg_match_all': 'use "Nette\Utils\Strings::matchAll()" instead'
+                'preg_replace': 'use "Nette\Utils\Strings::replace()" instead'
 
                 # forbid debug
                 'd': ''

--- a/config/rules.neon
+++ b/config/rules.neon
@@ -207,29 +207,30 @@ services:
         tags: [phpstan.rules.rule]
         arguments:
             forbiddenFunctions:
-                - dump_node
-                # use Strings::match() instead
-                - preg_match
-                - preg_match_all
-                - preg_replace
+                'dump_node': ''
+
+                'preg_match': 'use Strings::match() instead'
+                'preg_match_all': 'use Strings::matchAll() instead'
+                'preg_replace': 'use Strings::replace() instead'
+
                 # forbid debug
-                - 'd'
-                - 'dd'
-                - 'dump'
-                - 'var_dump'
-                - 'curl_*'
-                - 'extract'
-                - 'compact'
-                - 'spl_autoload_register'
-                - 'spl_autoload_unregister'
-                - array_walk
-                # there are handled in ReflectionProvider->has*()
-                - 'class_exists'
-                - 'interface_exists'
-                - 'method_exists'
-                - 'property_exists'
-                - 'function_exists'
-                - class_parents
-                - class_implements
-                - get_parent_class
-                - get_declared_classes
+                'd': ''
+                'dd': ''
+                'dump': ''
+                'var_dump': ''
+                'curl_*': ''
+                'extract': ''
+                'compact': ''
+                'spl_autoload_register': ''
+                'spl_autoload_unregister': ''
+                array_walk: ''
+
+                'class_exists': 'use ReflectionProvider->has*() instead'
+                'interface_exists': 'use ReflectionProvider->has*() instead'
+                'method_exists': 'use ReflectionProvider->has*() instead'
+                'property_exists': 'use ReflectionProvider->has*() instead'
+                'function_exists': 'use ReflectionProvider->has*() instead'
+                'class_parents': 'use ReflectionProvider->has*() instead'
+                'class_implements': 'use ReflectionProvider->has*() instead'
+                'get_parent_class': 'use ReflectionProvider->has*() instead'
+                'get_declared_classes': 'use ReflectionProvider->has*() instead'

--- a/config/rules.neon
+++ b/config/rules.neon
@@ -223,7 +223,7 @@ services:
                 'compact': ''
                 'spl_autoload_register': ''
                 'spl_autoload_unregister': ''
-                array_walk: ''
+                'array_walk': ''
 
                 'class_exists': 'use ReflectionProvider->has*() instead'
                 'interface_exists': 'use ReflectionProvider->has*() instead'


### PR DESCRIPTION
use more contributor friendly errors messages

before: `Function "preg_replace()" cannot be used/left in the code`
after: Function "preg_replace()" cannot be used/left in the code: use Strings::replace() instead`