### PR TITLE
Fix CI: remove ForbiddenComplexFuncCallRule

### DIFF
--- a/config/rules.neon
+++ b/config/rules.neon
@@ -29,14 +29,6 @@ services:
                 - 'Rector'
 
     -
-        class: Symplify\PHPStanRules\Rules\ForbiddenComplexFuncCallRule
-        tags: [phpstan.rules.rule]
-        arguments:
-            forbiddenComplexFunctions:
-                - array_filter
-            maximumStmtCount: 3
-
-    -
         class: Symplify\PHPStanRules\Rules\ForbiddenNodeRule
         tags: [phpstan.rules.rule]
         arguments:


### PR DESCRIPTION
symplify 10.1.3 seems removed ForbiddenComplexFuncCallRule, that cause error : 

```
_PHPStan_ae8980142\Nette\DI\ServiceCreationException: Service (Symplify\PHPStanRules\Rules\ForbiddenComplexFuncCallRule::__construct()): Class 'Symplify\PHPStanRules\Rules\ForbiddenComplexFuncCallRule' not found.
```

in CI, this PR try to solve it.